### PR TITLE
Update README for Luisella's benefit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
-## filescan: track files and python variable usage
+## filescan: track files and Python name usage
 
-We assume your account has sufficiant permissions to create,
+We assume your account has sufficient permissions to create,
 delete and modify the necessary database objects in the
 database you select.
 
-Under poetry control run
+filescan uses the [`python-dotenv`](https://pypi.org/project/python-dotenv/)
+module, meaning you can affect your program's environment by editing the
+value of `DBNAME` in the _.env_ file.
 
-    python filescan [path ...]
 
-You will be asked which database technology you want to use.
-Enter one of `postgresql`, `sqlite` or `mongo`.
+### Creating a database
 
-It then asks you for a database name. Your choice.
+At present the required database must exist before filescan
+runs, so you'll need to create it manually some other way.
 
-Finally it asks whether you want to create a new database.
-Unless the response is the three literal characters "yes"
-the program assumes you wish to use an existing database.
-A "yes" answer will require confirmation in the same way,
-since it will delete any existing database of the same name.
+Once created, to add the tables run the command
 
-The above is slightly misleading, as the present code is
-not capable of dropping and creating databases, so it should
-really talk about creating the tables, rather than the
-whole database. This should be fixed in short order.
+    poetry run alembic upgrade head
+
+### Runing the prograM
+
+Run the command
+
+    poetry run python -m filescan [path ...]
+
+Each of the arguments should be directory.
+By default the system uses a database called "default_db".
+You can change this by setting the DBNAME environment
+variable.
 
 The program then proceeds to scan the filestore starting
 from each of the paths given on the command line. Any
@@ -43,6 +48,5 @@ When filescan runs, it searches for a list of importable
 modules or packages with names matching "filescan_* will
 be imported and their `process` function will be called with
 the connection object as the first argument and the relevant
-Location object as the second.
-
-Each new or modified file processed
+Location object as the second for each new or modified file
+encountered.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,21 @@ The program then proceeds to scan the filestore starting
 from each of the paths given on the command line. Any
 directories it encounters with the names _.git_,
 _\_\_pycache\_\__ or _site\_packages_ will be ignored.
+\[TODO: make the ignored directory list configurable].
 
 Any Python files encountered are tokenised and indexed
 on all names used other than Python keywords, recording
 the file path, line number and character position of
-each occurrence.
+each occurrence. This has now been modified to use the
+new plugin architecture (see below).
+
+Processing specific file types with plugins
+-------------------------------------------
+
+When filescan runs, it searches for a list of importable
+modules or packages with names matching "filescan_* will
+be imported and their `process` function will be called with
+the connection object as the first argument and the relevant
+Location object as the second.
+
+Each new or modified file processed

--- a/mongo_store.py
+++ b/mongo_store.py
@@ -36,11 +36,11 @@ class Connection:
     def clear_seen_bits(self, prefix):
         self.document_class.objects(dirpath__startswith=prefix).update(seen=False)
 
-    def hash_for(self, checksum):
-        return len(FileRecord.objects(checksum=checksum)[:1]) == 1
+    def hash_for(self, hash):
+        return len(FileRecord.objects(checksum=hash)[:1]) == 1
 
-    def save_reference(self, checksum, name, line, pos):
-        TokenPos(checksum=checksum, name=name, line=line, pos=pos).save()
+    def save_reference(self, hash, name, line, pos):
+        TokenPos(checksum=hash, name=name, line=line, pos=pos).save()
 
     def location_for(self, dir_path, file_path):
         fieldnames = ["id", "modified", "checksum", "seen"]
@@ -49,20 +49,20 @@ class Connection:
         )
         return tuple(getattr(result, fld) for fld in fieldnames)
 
-    def update_details(self, id, modified, checksum, seen=True):
+    def update_details(self, id, modified, hash, seen=True):
         return self.document_class.objects(pk=id).update(
-            modified=modified, checksum=checksum, seen=seen
+            modified=modified, checksum=hash, seen=seen
         )
 
     def update_seen(self, id):
         self.document_class.objects(pk=id).update(seen=True)
 
-    def insert_location(self, file_path, dirpath, modified, checksum):
+    def insert_location(self, file_path, dirpath, modified, hash):
         rec = self.document_class(
             filename=file_path,
             dirpath=dirpath,
             modified=modified,
-            checksum=checksum,
+            checksum=hash,
             seen=True,
         )
         rec.save()

--- a/src/filescan/__init__.py
+++ b/src/filescan/__init__.py
@@ -40,6 +40,11 @@ def debug(*args, **kwargs):
 
 
 def scan_directory(base_dir: str, conn: Connection):
+    """
+    Recursively traverses a directory, noting which files
+    are new since the last scan, which have been modified
+    and which have been deleted.
+    """
     started: datetime = datetime.now()
     file_count = known_files = updated_files = 0
     unchanged_files = new_files = deleted_files = 0

--- a/src/filescan/filescan_python.py
+++ b/src/filescan/filescan_python.py
@@ -1,0 +1,33 @@
+from tokenize import tokenize
+import token
+import keyword as kw
+
+
+EXTENSIONS = [".py", ".pyw"]
+
+
+def process(conn, loc):
+    """
+    Add the non-keyword tokens to the position index for this file.
+    Only called when no checksum previously existed for the file's
+    current incarnation - otherwise we assume scanning took place
+    when the original checksum was created.
+    XXX The above assumption fails when the first incarnation of a
+        Python source file doesn't have the ".py" extension. Hmmm.
+        Maybe one solution is an explicit test for the existence of
+        at least one TokenPos for a given checksum, but even this
+        would cause repeated parsing of files containing no names.
+    """
+    filepath = f"{loc.dirpath}{loc.filename}"
+    if any(filepath.endswith(ext) for ext in EXTENSIONS):
+        with open(filepath, "rb") as inf:
+            try:
+                for t in tokenize(inf.readline):
+                    if t.type == token.NAME and not kw.iskeyword(t.string):
+                        conn.save_reference(
+                            loc.checksum, 1, t.string, t.start[0], t.start[1]
+                        )
+            except Exception as e:
+                print(
+                    f"** {filepath}: {type(e)}\n   {e}"
+                )  # XXX: sensible handling of parse and other errors

--- a/src/filescan/sqlalchemy_store.py
+++ b/src/filescan/sqlalchemy_store.py
@@ -75,13 +75,13 @@ class Location(Model, SerializerMixin):
     filename: Mapped[str] = mapped_column(String())
     dirpath: Mapped[str] = mapped_column(String())
     modified: Mapped[float] = mapped_column(Float())
+    seen: Mapped[bool] = mapped_column(Boolean())
+    filesize: Mapped[int]
+    serialize_rules = ("-checksum_id", "checksum.checksum")
     checksum_id: Mapped[int] = mapped_column(
         ForeignKey("checksum.id"), nullable=True, index=True
     )
     checksum: Mapped[Checksum] = relationship("Checksum", back_populates="locations")
-    seen: Mapped[bool] = mapped_column(Boolean())
-    filesize: Mapped[int]
-    serialize_rules = ("-checksum_id", "checksum.checksum")
 
 
 class TokenPos(Model, SerializerMixin):
@@ -121,9 +121,9 @@ class Connection:
     class DoesNotExist(Exception):
         ...
 
-    def __init__(self):
+    def __init__(self, create=False, echo=False):
         self.db_url = DB_URL
-        self.engine = create_engine(self.db_url, echo=False)
+        self.engine = create_engine(self.db_url, echo=echo)
         self.session = sessionmaker(self.engine)()
 
     def all_file_count(self, prefix):

--- a/src/filescan/sqlalchemy_store.py
+++ b/src/filescan/sqlalchemy_store.py
@@ -166,9 +166,10 @@ class Connection:
         Checksum file's content, creating a new Checksum row if necessary.
 
         File scanning was formerly performed here, but is now move to
-        plugins. Importble modules with names matching "filescan_* will"
+        plugins. Importable modules with names matching "filescan_* will"
         be imported and their `process` function will be called with
-        the relevant Location object as the sole argument.
+        the connection object as the first argument and the relevant
+        Location object as the second.
         """
         try:
             new_file = open(file_path, "rb")

--- a/src/filescan/sqlalchemy_store.py
+++ b/src/filescan/sqlalchemy_store.py
@@ -174,7 +174,7 @@ class Connection:
         try:
             new_file = open(file_path, "rb")
             hash = hashlib.file_digest(new_file, "sha256").hexdigest()
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             return None
         cs = self.session.query(Checksum).filter_by(checksum=hash).first()
         if cs is None:


### PR DESCRIPTION
Describes the very simple plugin interface you can use to find out about files of interest that you would like to process in specific ways.

This commit provides a simple (_but provisional_) interface to let you use filescan to drive processing of files with particular characteristics. Rather than dictate which files your plugin is "allowed" to handle, its `process(conn, loc)` method is called for every new or modified file encountered (_caveat_: XXX).

Plugin module usage is briefly described. Is it time to start documenting this stuff yet?